### PR TITLE
Allow missing the local file

### DIFF
--- a/cfg.go
+++ b/cfg.go
@@ -161,7 +161,7 @@ func Load(params *Params) (Config, error) {
 	}
 
 	envName := c.getEnv()
-	if err := c.mergeEnv(envName); err != nil {
+	if err := c.mergeEnv(envName); err != nil && envName != localConfigEnv {
 		return nil, fmt.Errorf("error merging \"%s\" configuration file", envName)
 	}
 	c.loadEnvConfigFile()

--- a/cfg_test.go
+++ b/cfg_test.go
@@ -106,6 +106,13 @@ func TestLoad(t *testing.T) {
 			envNameValue:  "staging",
 			expectedError: errors.New("error merging \"staging\" configuration file"),
 		},
+		"TestNoEnvSetAndMissingLocal": {
+			params: &cfg.Params{
+				Path: "./confs/confMissingLocal",
+			},
+			envNameValue:  "",
+			expectedError: nil,
+		},
 	}
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {

--- a/confs/confMissingLocal/default.yaml
+++ b/confs/confMissingLocal/default.yaml
@@ -1,0 +1,3 @@
+services:
+  foo:
+    bar: http://default.com

--- a/confs/confMissingLocal/production.yaml
+++ b/confs/confMissingLocal/production.yaml
@@ -1,0 +1,3 @@
+services:
+  foo:
+    bar: http://production.com


### PR DESCRIPTION
When the `GOENV` variable is not set, cfg tries to read and merge from the `local` file, if it does not exist it throws an error. This library was inspired by `node-config` and their local file works as follow, see https://github.com/lorenwest/node-config/wiki/Configuration-Files#local-files 

This shouldn't cause a panic and prevent any app from running: 
<img width="727" alt="screen shot 2018-12-20 at 11 37 56" src="https://user-images.githubusercontent.com/8670901/50301016-bc511700-044b-11e9-8faa-fa48b4cc918a.png">
