### PR TITLE
Add support for overriding lists values with env vars

### DIFF
--- a/cfg_test.go
+++ b/cfg_test.go
@@ -2,7 +2,6 @@ package cfg_test
 
 import (
 	"errors"
-	"fmt"
 	"os"
 	"reflect"
 	"testing"
@@ -173,6 +172,9 @@ func TestGet(t *testing.T) {
 func TestEnvVariablesReplacement(t *testing.T) {
 	os.Setenv("HOST", "0.0.0.0")
 	os.Setenv("FLOAT", "10.5")
+	os.Setenv("ONE", "one")
+	os.Setenv("TWO", "2")
+
 	config, err := cfg.Load(&cfg.Params{
 		Path: "./confs/conf",
 	})
@@ -194,10 +196,12 @@ func TestEnvVariablesReplacement(t *testing.T) {
 		"TestFloatEnv": {
 			key: "services.foo",
 			expectedConfigMap: map[string]interface{}{
-				"string": "foo",
-				"int":    42,
-				"float":  10.5,
-				"bool":   false,
+				"string":       "foo",
+				"int":          42,
+				"float":        10.5,
+				"bool":         false,
+				"multi_array":  []interface{}{"one", 2},
+				"single_array": []interface{}{"one"},
 			},
 		},
 		"TestSingleMissingDeepKey": {
@@ -213,7 +217,7 @@ func TestEnvVariablesReplacement(t *testing.T) {
 			expectedConfigMap: nil,
 		},
 	}
-	fmt.Println(config.AllSettings())
+
 	for testName, testCase := range tests {
 		t.Run(testName, func(t *testing.T) {
 			configMap := config.Get(testCase.key)

--- a/confs/conf/environment-variables.yaml
+++ b/confs/conf/environment-variables.yaml
@@ -8,3 +8,10 @@ services:
     int: "INT"
     float: "FLOAT"
     bool: "BOOL"
+    multi_array:
+      - "ONE"
+      - "NON_EXISTING_VAR"
+      - "TWO"
+    single_array:
+      - "ONE"
+

--- a/example/main.go
+++ b/example/main.go
@@ -25,6 +25,6 @@ func main() {
 	mainServiceConfig := config.Get("services.main")
 
 	// Only to pretty print
-	mainServiceConfigPretty, err := json.MarshalIndent(mainServiceConfig, "", "  ")
+	mainServiceConfigPretty, _ := json.MarshalIndent(mainServiceConfig, "", "  ")
 	fmt.Printf("%s", string(mainServiceConfigPretty))
 }


### PR DESCRIPTION
This feature makes the following posible. There was no way of doing it before.

.env
```
VAR='foo'
```

environment-variables.yaml
```
array:
  - VAR
```


Then

```go

config.Get('array') == [ 'foo' ] // true 

```
